### PR TITLE
Improved metadata, second attempt

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		C1220FC02AFB122F007E5055 /* ImageWellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1220FBF2AFB122F007E5055 /* ImageWellView.swift */; };
 		C1ADEC2C2B16957800E142CA /* FolderMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ADEC2B2B16957800E142CA /* FolderMonitor.swift */; };
 		D7B03F2029D42F9900DF89DD /* SDModelAttentionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */; };
+		DF1521DE2B95014100D7A82E /* MetadataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1521DD2B95014100D7A82E /* MetadataHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -132,6 +133,7 @@
 		C1220FBF2AFB122F007E5055 /* ImageWellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageWellView.swift; sourceTree = "<group>"; };
 		C1ADEC2B2B16957800E142CA /* FolderMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderMonitor.swift; sourceTree = "<group>"; };
 		D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDModelAttentionType.swift; sourceTree = "<group>"; };
+		DF1521DD2B95014100D7A82E /* MetadataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +176,7 @@
 				9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */,
 				03FD231A295F7A81006EEEE2 /* Upscaler.swift */,
 				71D315152B2A584E007FFDEB /* NotificationController.swift */,
+				DF1521DD2B95014100D7A82E /* MetadataHelper.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -439,6 +442,7 @@
 				03D280F2294FD60E00C7D184 /* PromptView.swift in Sources */,
 				03FD2319295F74B6006EEEE2 /* RealESRGAN.mlmodel in Sources */,
 				035EE000295A224900080D18 /* ModelView.swift in Sources */,
+				DF1521DE2B95014100D7A82E /* MetadataHelper.swift in Sources */,
 				03E075792968A153003488F9 /* CircularProgressView.swift in Sources */,
 				58FF218829FAE96200A70C7C /* ControlNetView.swift in Sources */,
 				C11A03882B099D9600540F7F /* JobQueueView.swift in Sources */,
@@ -641,7 +645,7 @@
 				CURRENT_PROJECT_VERSION = 5.0;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Mochi Diffusion/Preview Content\"";
-				DEVELOPMENT_TEAM = TCQ6328PP6;
+				DEVELOPMENT_TEAM = SY87JRZ2T6;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -674,7 +678,7 @@
 				CURRENT_PROJECT_VERSION = 5.0;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Mochi Diffusion/Preview Content\"";
-				DEVELOPMENT_TEAM = TCQ6328PP6;
+				DEVELOPMENT_TEAM = SY87JRZ2T6;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Mochi Diffusion/Model/SDImage.swift
+++ b/Mochi Diffusion/Model/SDImage.swift
@@ -111,13 +111,9 @@ extension SDImage {
             1,
             nil
         ) else { return nil }
-        let iptc = await [
-            kCGImagePropertyIPTCCaptionAbstract: metadata(),
-            kCGImagePropertyIPTCOriginatingProgram: "Mochi Diffusion",
-            kCGImagePropertyIPTCProgramVersion: "\(await NSApplication.appVersion)"
-        ]
-        let meta = [kCGImagePropertyIPTCDictionary: iptc]
-        CGImageDestinationAddImage(destination, image, meta as CFDictionary)
+        let metadata = CreateMetadata(PositivePrompt: prompt, NegativePrompt: negativePrompt, Width: width, Height: height, Seed: seed, GuidanceScale: Float(guidanceScale), Scheduler: scheduler, StepCount: steps, CurrentModel: model, Upscaler: upscaler, CurrentStyle: "", ComputeUnits: mlComputeUnit ?? .cpuAndGPU)
+
+         CGImageDestinationAddImage(destination, image, metadata)
         guard CGImageDestinationFinalize(destination) else { return nil }
         return data as Data
     }

--- a/Mochi Diffusion/Model/SDImage.swift
+++ b/Mochi Diffusion/Model/SDImage.swift
@@ -111,7 +111,7 @@ extension SDImage {
             1,
             nil
         ) else { return nil }
-        let metadata = CreateMetadata(PositivePrompt: prompt, NegativePrompt: negativePrompt, Width: width, Height: height, Seed: seed, GuidanceScale: Float(guidanceScale), Scheduler: scheduler, StepCount: steps, CurrentModel: model, Upscaler: upscaler, CurrentStyle: "", ComputeUnits: mlComputeUnit ?? .cpuAndGPU)
+        let metadata = CreateMetadata(positivePrompt: prompt, negativePrompt: negativePrompt, width: width, height: height, seed: seed, guidanceScale: Float(guidanceScale), scheduler: scheduler, stepCount: steps, currentModel: model, upscaler: upscaler, currentStyle: "", computeUnits: mlComputeUnit ?? .cpuAndGPU)
 
          CGImageDestinationAddImage(destination, image, metadata)
         guard CGImageDestinationFinalize(destination) else { return nil }

--- a/Mochi Diffusion/Support/MetadataHelper.swift
+++ b/Mochi Diffusion/Support/MetadataHelper.swift
@@ -12,14 +12,14 @@ import CoreML
 // import GuernikaKit
 import StableDiffusion
 
-func CreateMetadata (PositivePrompt: String, NegativePrompt: String, Width: Int, Height: Int, Seed: UInt32, GuidanceScale: Float, Scheduler: Scheduler, StepCount: Int, CurrentModel: String, Upscaler: String, CurrentStyle: String, ComputeUnits: MLComputeUnits)-> NSMutableDictionary{
-    var SchedulerString = ""
+func CreateMetadata (positivePrompt: String, negativePrompt: String, width: Int, height: Int, seed: UInt32, guidanceScale: Float, scheduler: Scheduler, stepCount: Int, currentModel: String, upscaler: String, currentStyle: String, computeUnits: MLComputeUnits)-> NSMutableDictionary{
+    var schedulerString = ""
     var mlComputeUnit = ""
     /// Schedulers for ML-Stable-diffusion
-    if Scheduler == .pndmScheduler{
-        SchedulerString = "PNDM"}
-    if Scheduler == .dpmSolverMultistepScheduler{
-        SchedulerString = "DPM-Solver++"}
+    if scheduler == .pndmScheduler{
+        schedulerString = "PNDM"}
+    if scheduler == .dpmSolverMultistepScheduler{
+        schedulerString = "DPM-Solver++"}
     
     /// Schedulers for Guernika kit
 //    if Scheduler == .ddim{
@@ -48,36 +48,36 @@ func CreateMetadata (PositivePrompt: String, NegativePrompt: String, Width: Int,
 //        SchedulerString = "PNDM"}
     
     
-    if ComputeUnits == .cpuOnly{
+    if computeUnits == .cpuOnly{
         mlComputeUnit = "cpuOnly"}
-    if ComputeUnits == .cpuAndGPU{
+    if computeUnits == .cpuAndGPU{
         mlComputeUnit = "cpuAndGPU"}
-    if ComputeUnits == .cpuAndNeuralEngine{
+    if computeUnits == .cpuAndNeuralEngine{
         mlComputeUnit = "cpuAndNeuralEngine"}
   
     // Add metadata
     let meta = NSMutableDictionary()
-    // EXIF Metadata (User Comment)
+    // EXIF Metadata (User Comment) - used by most other apps "c" and "uc" for prompts are established naming conventions kept for compatability.
     let exifMetadata = NSMutableDictionary()
-    exifMetadata[kCGImagePropertyExifUserComment as String] = "{\"c\":\"\(PositivePrompt)\", \"uc\":\"\(NegativePrompt)\", \"seed\":\(Seed), \"guidance_scale\":\(GuidanceScale), \"sampler\":\"\(SchedulerString)\", \"steps\":\(StepCount), \"model\":\"\(CurrentModel)\", \"Upscaler\":\"\(Upscaler)\", \"styles\":\"\(CurrentStyle)\"}"
+    exifMetadata[kCGImagePropertyExifUserComment as String] = "{\"c\":\"\(positivePrompt)\", \"uc\":\"\(negativePrompt)\", \"seed\":\(seed), \"guidance_scale\":\(guidanceScale), \"sampler\":\"\(schedulerString)\", \"steps\":\(stepCount), \"model\":\"\(currentModel)\", \"Upscaler\":\"\(upscaler)\", \"styles\":\"\(currentStyle)\"}"
     meta[kCGImagePropertyExifDictionary as String] = exifMetadata
     // IPTC Metadata (Caption)
     let iptcMetadata = NSMutableDictionary()
     
     iptcMetadata[kCGImagePropertyIPTCCaptionAbstract as String] = """
-    \(Metadata.includeInImage.rawValue): \(PositivePrompt); \
-    \(Metadata.excludeFromImage.rawValue): \(NegativePrompt); \
-    \(Metadata.model.rawValue): \(CurrentModel); \
-    \(Metadata.steps.rawValue): \(StepCount); \
-    \(Metadata.guidanceScale.rawValue): \(GuidanceScale); \
-    \(Metadata.seed.rawValue): \(Seed); \
-    \(Metadata.size.rawValue): \(Width)x\(Height);
+    \(Metadata.includeInImage.rawValue): \(positivePrompt); \
+    \(Metadata.excludeFromImage.rawValue): \(negativePrompt); \
+    \(Metadata.model.rawValue): \(currentModel); \
+    \(Metadata.steps.rawValue): \(stepCount); \
+    \(Metadata.guidanceScale.rawValue): \(guidanceScale); \
+    \(Metadata.seed.rawValue): \(seed); \
+    \(Metadata.size.rawValue): \(width)x\(height);
     """
     +
-    (!Upscaler.isEmpty ? " \(Metadata.upscaler.rawValue): \(Upscaler); " : " ")
+    (!upscaler.isEmpty ? " \(Metadata.upscaler.rawValue): \(upscaler); " : " ")
     +
     """
-    \(Metadata.scheduler.rawValue): \(Scheduler.rawValue); \
+    \(Metadata.scheduler.rawValue): \(scheduler.rawValue); \
     \(Metadata.mlComputeUnit.rawValue): \(mlComputeUnit); \
     \(Metadata.generator.rawValue): Mochi Diffusion \(NSApplication.appVersion)
     """
@@ -89,7 +89,7 @@ func CreateMetadata (PositivePrompt: String, NegativePrompt: String, Width: Int,
     
     // TIFF Metadata (Image Description)
     let tiffMetadata = NSMutableDictionary()
-    tiffMetadata[kCGImagePropertyTIFFImageDescription as String] = "c:\(PositivePrompt), uc:\(NegativePrompt), seed:\(Seed), Guidance Scale:\(GuidanceScale), Sampler:\(SchedulerString), Steps:\(StepCount), Model:\(CurrentModel), upscaler:\(Upscaler), Size:\(Width)x\(Height)"
+    tiffMetadata[kCGImagePropertyTIFFImageDescription as String] = "c:\(positivePrompt), uc:\(negativePrompt), seed:\(seed), Guidance Scale:\(guidanceScale), Sampler:\(schedulerString), Steps:\(stepCount), Model:\(currentModel), upscaler:\(upscaler), Size:\(width)x\(height)"
     meta[kCGImagePropertyTIFFDictionary as String] = tiffMetadata
     return meta
 }

--- a/Mochi Diffusion/Support/MetadataHelper.swift
+++ b/Mochi Diffusion/Support/MetadataHelper.swift
@@ -1,0 +1,95 @@
+//
+//  MetadataHelper.swift
+//  Mochi Diffusion
+//
+//  Created by Jones on 18/02/2024.
+//
+
+import Foundation
+import CoreGraphics
+import AppKit
+import CoreML
+// import GuernikaKit
+import StableDiffusion
+
+func CreateMetadata (PositivePrompt: String, NegativePrompt: String, Width: Int, Height: Int, Seed: UInt32, GuidanceScale: Float, Scheduler: Scheduler, StepCount: Int, CurrentModel: String, Upscaler: String, CurrentStyle: String, ComputeUnits: MLComputeUnits)-> NSMutableDictionary{
+    var SchedulerString = ""
+    var mlComputeUnit = ""
+    /// Schedulers for ML-Stable-diffusion
+    if Scheduler == .pndmScheduler{
+        SchedulerString = "PNDM"}
+    if Scheduler == .dpmSolverMultistepScheduler{
+        SchedulerString = "DPM-Solver++"}
+    
+    /// Schedulers for Guernika kit
+//    if Scheduler == .ddim{
+//        SchedulerString = "DDIM"}
+//    if Scheduler == .dpmSolverMultistep{
+//        SchedulerString = "DPM++ 2M"}
+//    if Scheduler == .dpmSolverMultistepKarras{
+//        SchedulerString = "DPM++ 2M Karras"}
+//    if Scheduler == .dpmSolverSinglestep{
+//        SchedulerString = "DPM++ SDE"}
+//    if Scheduler == .dpmSolverSinglestepKarras{
+//        SchedulerString = "DPM++ SDE Karras"}
+//    if Scheduler == .dpm2{
+//        SchedulerString = "DPM2"}
+//    if Scheduler == .dpm2Karras{
+//        SchedulerString = "DPM2 Karras"}
+//    if Scheduler == .eulerDiscrete{
+//        SchedulerString = "Euler"}
+//    if Scheduler == .eulerDiscreteKarras{
+//        SchedulerString = "Euler Karras"}
+//    if Scheduler == .eulerAncenstralDiscrete{
+//        SchedulerString = "Euler Ancenstral"}
+//    if Scheduler == .lcm{
+//        SchedulerString = "LCM"}
+//    if Scheduler == .pndm{
+//        SchedulerString = "PNDM"}
+    
+    
+    if ComputeUnits == .cpuOnly{
+        mlComputeUnit = "cpuOnly"}
+    if ComputeUnits == .cpuAndGPU{
+        mlComputeUnit = "cpuAndGPU"}
+    if ComputeUnits == .cpuAndNeuralEngine{
+        mlComputeUnit = "cpuAndNeuralEngine"}
+  
+    // Add metadata
+    let meta = NSMutableDictionary()
+    // EXIF Metadata (User Comment)
+    let exifMetadata = NSMutableDictionary()
+    exifMetadata[kCGImagePropertyExifUserComment as String] = "{\"c\":\"\(PositivePrompt)\", \"uc\":\"\(NegativePrompt)\", \"seed\":\(Seed), \"guidance_scale\":\(GuidanceScale), \"sampler\":\"\(SchedulerString)\", \"steps\":\(StepCount), \"model\":\"\(CurrentModel)\", \"Upscaler\":\"\(Upscaler)\", \"styles\":\"\(CurrentStyle)\"}"
+    meta[kCGImagePropertyExifDictionary as String] = exifMetadata
+    // IPTC Metadata (Caption)
+    let iptcMetadata = NSMutableDictionary()
+    
+    iptcMetadata[kCGImagePropertyIPTCCaptionAbstract as String] = """
+    \(Metadata.includeInImage.rawValue): \(PositivePrompt); \
+    \(Metadata.excludeFromImage.rawValue): \(NegativePrompt); \
+    \(Metadata.model.rawValue): \(CurrentModel); \
+    \(Metadata.steps.rawValue): \(StepCount); \
+    \(Metadata.guidanceScale.rawValue): \(GuidanceScale); \
+    \(Metadata.seed.rawValue): \(Seed); \
+    \(Metadata.size.rawValue): \(Width)x\(Height);
+    """
+    +
+    (!Upscaler.isEmpty ? " \(Metadata.upscaler.rawValue): \(Upscaler); " : " ")
+    +
+    """
+    \(Metadata.scheduler.rawValue): \(Scheduler.rawValue); \
+    \(Metadata.mlComputeUnit.rawValue): \(mlComputeUnit); \
+    \(Metadata.generator.rawValue): Mochi Diffusion \(NSApplication.appVersion)
+    """
+    
+        meta[kCGImagePropertyIPTCCaptionAbstract as String] = iptcMetadata
+        meta[kCGImagePropertyIPTCOriginatingProgram as String] = "Mochi Diffusion"
+        meta[kCGImagePropertyIPTCProgramVersion as String] = "\(NSApplication.appVersion)"
+        meta[kCGImagePropertyIPTCDictionary as String] = iptcMetadata
+    
+    // TIFF Metadata (Image Description)
+    let tiffMetadata = NSMutableDictionary()
+    tiffMetadata[kCGImagePropertyTIFFImageDescription as String] = "c:\(PositivePrompt), uc:\(NegativePrompt), seed:\(Seed), Guidance Scale:\(GuidanceScale), Sampler:\(SchedulerString), Steps:\(StepCount), Model:\(CurrentModel), upscaler:\(Upscaler), Size:\(Width)x\(Height)"
+    meta[kCGImagePropertyTIFFDictionary as String] = tiffMetadata
+    return meta
+}


### PR DESCRIPTION
I have improved and added to the metadata capabilities of MochiDiffusion so metadata can be ported between apps via the saved images.

I have kept the remaining Metadata and added various others including Xmp.exif.UserComment, this is a json formatted string that matches with the A1111 api protocol so as to be compatible with CivitAI, all the main python generators, popular Mac apps and makes it easier link to other apps later too.

the main file added is MetadataHelper.swift which is my ported code as well as the existing metadata merged. This file is east to maintain and I can see plenty to add later when the transition to Guernika is complete, but I have left placeholders ready for the new schedulers.

the other change is amending the SDImage.swift imagedata function, to call for the metadata