### PR TITLE
Add SD3 pipeline

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -759,8 +759,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/ml-stable-diffusion";
 			requirement = {
-				kind = revision;
-				revision = d1f0604fab5345011e0b9f5b87ee0c155612565f;
+				branch = main;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -759,8 +759,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/ml-stable-diffusion";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = d1f0604fab5345011e0b9f5b87ee0c155612565f;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Mochi Diffusion/Model/SDModel.swift
+++ b/Mochi Diffusion/Model/SDModel.swift
@@ -17,6 +17,7 @@ struct SDModel: Identifiable {
     let attention: SDModelAttentionType
     let controlNet: [String]
     let isXL: Bool
+    let isSD3: Bool
     let inputSize: CGSize?
     let tokenizer: Tokenizer?
 
@@ -28,6 +29,7 @@ struct SDModel: Identifiable {
         }
 
         let isXL = identifyIfXL(url)
+        let isSD3 = identifyIfSD3(url)
         let size = identifyInputSize(url)
 
         self.url = url
@@ -40,6 +42,7 @@ struct SDModel: Identifiable {
             self.controlNet = []
         }
         self.isXL = isXL
+        self.isSD3 = isSD3
         self.inputSize = size
         self.tokenizer = Tokenizer(modelDir: url)
     }
@@ -108,11 +111,39 @@ private func identifyIfXL(_ url: URL) -> Bool {
     }
 }
 
+private func identifyIfSD3(_ url: URL) -> Bool {
+    guard let metadataURL = unetMetadataURL(from: url) else {
+        logger.warning("No model metadata found at '\(url)'")
+        return false
+    }
+
+    struct ModelMetadata: Decodable {
+        let inputSchema: [[String: String]]
+    }
+
+    do {
+        let jsonData = try Data(contentsOf: metadataURL)
+        let metadatas = try JSONDecoder().decode([ModelMetadata].self, from: jsonData)
+
+        guard metadatas.count == 1 else {
+            return false
+        }
+
+        // SD3 models have 4 inputs with one named "latent_image_embeddings"
+        let inputNames = metadatas[0].inputSchema.compactMap { $0["name"] }
+        return inputNames.contains("latent_image_embeddings")
+    } catch {
+        logger.warning("Failed to parse model metadata at '\(metadataURL)': \(error)")
+        return false
+    }
+}
+
 private func unetMetadataURL(from url: URL) -> URL? {
     let potentialMetadataURLs = [
         url.appending(components: "Unet.mlmodelc", "metadata.json"),
         url.appending(components: "UnetChunk1.mlmodelc", "metadata.json"),
         url.appending(components: "ControlledUnet.mlmodelc", "metadata.json"),
+        url.appending(components: "MultiModalDiffusionTransformer.mlmodelc", "metadata.json"),
     ]
 
     return potentialMetadataURLs.first {

--- a/Mochi Diffusion/Model/Scheduler.swift
+++ b/Mochi Diffusion/Model/Scheduler.swift
@@ -13,6 +13,8 @@ enum Scheduler: String, CaseIterable {
     case pndmScheduler = "PNDM"
     /// Scheduler that uses a second order DPM-Solver++ algorithm
     case dpmSolverMultistepScheduler = "DPM-Solver++"
+    /// Scheduler for rectified flow based multimodal diffusion transformer models
+    case discreteFlowScheduler = "Flow Match Euler Discrete"
 }
 
 func convertScheduler(_ scheduler: Scheduler) -> StableDiffusionScheduler {
@@ -21,5 +23,7 @@ func convertScheduler(_ scheduler: Scheduler) -> StableDiffusionScheduler {
         return StableDiffusionScheduler.pndmScheduler
     case .dpmSolverMultistepScheduler:
         return StableDiffusionScheduler.dpmSolverMultistepScheduler
+    case .discreteFlowScheduler:
+        return StableDiffusionScheduler.discreteFlowScheduler
     }
 }

--- a/Mochi Diffusion/Support/ImageController.swift
+++ b/Mochi Diffusion/Support/ImageController.swift
@@ -287,6 +287,7 @@ final class ImageController: ObservableObject {
         let genConfig = GenerationConfig(
             pipelineConfig: pipelineConfig,
             isXL: model.isXL,
+            isSD3: model.isSD3,
             autosaveImages: autosaveImages,
             imageDir: imageDir,
             imageType: imageType,

--- a/Mochi Diffusion/Support/ImageGenerator.swift
+++ b/Mochi Diffusion/Support/ImageGenerator.swift
@@ -15,6 +15,7 @@ struct GenerationConfig: Sendable, Identifiable {
     let id = UUID()
     var pipelineConfig: StableDiffusionPipeline.Configuration
     var isXL: Bool
+    var isSD3: Bool
     var autosaveImages: Bool
     var imageDir: String
     var imageType: String
@@ -192,6 +193,12 @@ struct GenerationConfig: Sendable, Identifiable {
                 configuration: config,
                 reduceMemory: reduceMemory
             )
+        } else if model.isSD3 {
+            self.pipeline = try StableDiffusion3Pipeline(
+                resourcesAt: model.url,
+                configuration: config,
+                reduceMemory: reduceMemory
+            )
         } else {
             self.pipeline = try StableDiffusionPipeline(
                 resourcesAt: model.url,
@@ -222,6 +229,13 @@ struct GenerationConfig: Sendable, Identifiable {
             config.pipelineConfig.encoderScaleFactor = 0.13025
             config.pipelineConfig.decoderScaleFactor = 0.13025
             config.pipelineConfig.schedulerTimestepSpacing = .karras
+        }
+
+        if config.isSD3 {
+            config.pipelineConfig.encoderScaleFactor = 1.5305
+            config.pipelineConfig.decoderScaleFactor = 1.5305
+            config.pipelineConfig.decoderShiftFactor = 0.0609
+            config.pipelineConfig.schedulerTimestepShift = 3.0
         }
 
         var sdi = SDImage()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/MochiDiffusion/MochiDiffusion/blob/main/CONTRIBUTING.md)

### Description:

Hi there - here is a PR to enable the new SD3 pipeline for MochiDiffusion. The models can be downloaded here: 
512x512 no T5: https://huggingface.co/argmaxinc/coreml-stable-diffusion-3-medium/tree/main
1024x1024 with T5: https://huggingface.co/argmaxinc/coreml-stable-diffusion-3-medium-1024-t5/tree/main

These were generated with [DiffusionKit](https://github.com/argmaxinc/diffusionkit) in conjunction with [ml-stable-diffusion](https://github.com/apple/ml-stable-diffusion) for the shared text encoders.

Please note the the SD3 PR into ml-stable-diffusion is currently under review, and will need to be updated to main when merged https://github.com/apple/ml-stable-diffusion/pull/329

Additionally, the image to image is not yet supported, so the app will just start from the beginning when using a starting image.

<img width="1108" alt="image" src="https://github.com/MochiDiffusion/MochiDiffusion/assets/1981179/73ed2b62-5d6f-4923-a124-9b9255bd34f4">

![image](https://github.com/MochiDiffusion/MochiDiffusion/assets/1981179/51e5d264-4d65-41b8-80ab-40a0a80d8485)

