### PR TITLE
feat: right-click to set image file Finder color tags, shown as emoji

### DIFF
--- a/Mochi Diffusion/Model/ImageStore.swift
+++ b/Mochi Diffusion/Model/ImageStore.swift
@@ -116,6 +116,12 @@ enum ImagesSortType: String {
         }
     }
 
+    func updateMetadata(_ sdi: SDImage, colorNumber: Int) {
+        guard let index = index(for: sdi.id) else { return }
+        allImages[index] = sdi
+        allImages[index].finderTagColorNumber = colorNumber
+    }
+
     func update(_ sdi: SDImage) {
         guard let index = index(for: sdi.id) else { return }
         allImages[index] = sdi

--- a/Mochi Diffusion/Model/SDImage.swift
+++ b/Mochi Diffusion/Model/SDImage.swift
@@ -30,6 +30,7 @@ struct SDImage: Identifiable, Hashable {
     var upscaler = ""
     var isUpscaling = false
     var path = ""
+    var finderTagColorNumber = 0
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)

--- a/Mochi Diffusion/Support/Functions.swift
+++ b/Mochi Diffusion/Support/Functions.swift
@@ -72,9 +72,9 @@ func createSDImageFromURL(_ url: URL) -> SDImage? {
             atPath: url.path(percentEncoded: false))
     else { return nil }
     let maybeDateModified = attr[FileAttributeKey.modificationDate] as? Date
-    
+
     let finderTagColorNumber = getFinderTagColorNumber(url)
-    
+
     guard let dateModified = maybeDateModified else { return nil }
     guard let cgImageSource = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
     let imageIndex = CGImageSourceGetPrimaryImageIndex(cgImageSource)

--- a/Mochi Diffusion/Views/GalleryItemView.swift
+++ b/Mochi Diffusion/Views/GalleryItemView.swift
@@ -81,6 +81,10 @@ struct GalleryItemView: View {
                 if sdi.isUpscaling {
                     UpscalingAnimationView()
                 }
+                Text(finderTagColorNumberToString(self.sdi.finderTagColorNumber))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+                    .padding(8)
             }
         } else {
             Color.clear

--- a/Mochi Diffusion/Views/GalleryView.swift
+++ b/Mochi Diffusion/Views/GalleryView.swift
@@ -220,6 +220,88 @@ struct GalleryView: View {
                     )
                 }
             }
+            Section {
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 6)
+                    }
+                } label: {
+                    Text(
+                        "❤️ Set Finder Tag to Red",
+                        comment: "Mark this image Red, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 7)
+                    }
+                } label: {
+                    Text(
+                        "🔥 Set Finder Tag to Orange",
+                        comment: "Mark this image Orange, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 5)
+                    }
+                } label: {
+                    Text(
+                        "⭐️ Set Finder Tag to Yellow",
+                        comment: "Mark this image Yellow, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 2)
+                    }
+                } label: {
+                    Text(
+                        "🍏 Set Finder Tag to Green",
+                        comment: "Mark this image Green, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 4)
+                    }
+                } label: {
+                    Text(
+                        "💠 Set Finder Tag to Blue",
+                        comment: "Mark this image Blue, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 3)
+                    }
+                } label: {
+                    Text(
+                        "🦄 Set Finder Tag to Purple",
+                        comment: "Mark this image Purple, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        setFinderTagColorNumber(sdi, colorNumber: 1)
+                    }
+                } label: {
+                    Text(
+                        "☑️ Set Finder Tag to Gray",
+                        comment: "Mark this image Gray, with Finder metadata tag"
+                    )
+                }
+                Button {
+                    Task {
+                        clearFinderTags(sdi)
+                    }
+                } label: {
+                    Text(
+                        "Clear Finder Tags",
+                        comment: "Clear all Finder metadata color tags"
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When browsing generated images, right-click and tag a particular image with a star (yellow), heart (red), flame (orange), and more (7 emoji/colors total). Tags are stored natively in macOS and show up in Finder (implemented as decades-old HFS+/APFS Finder tag colors, works on iOS and iPadOS too). (The emoji are arbitrary but the color of emoji need to match Apple's predefined seven colors for this system to make sense.)