### PR TITLE
feat: implement advanced filter text field with filtering logic

### DIFF
--- a/Mochi Diffusion.xcodeproj/project.pbxproj
+++ b/Mochi Diffusion.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		03FD231B295F7A81006EEEE2 /* Upscaler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FD231A295F7A81006EEEE2 /* Upscaler.swift */; };
 		58FF218829FAE96200A70C7C /* ControlNetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FF218729FAE96200A70C7C /* ControlNetView.swift */; };
 		71D315162B2A584E007FFDEB /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D315152B2A584E007FFDEB /* NotificationController.swift */; };
+		9401BC6F2CB9E9E100F00DDE /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9401BC6E2CB9E9E100F00DDE /* Filter.swift */; };
+		9401BC712CB9ECA500F00DDE /* FilterTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9401BC702CB9ECA500F00DDE /* FilterTagView.swift */; };
+		9485F21C2CB97B53002623B7 /* FilterTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9485F21B2CB97B53002623B7 /* FilterTextFieldView.swift */; };
 		948853A52A543CB200B4AD86 /* GalleryPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 948853A42A543CB200B4AD86 /* GalleryPreviewView.swift */; };
 		9B7392C3298DEAC2006F03D5 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */; };
 		C116D4952AFC382E00314FE3 /* MochiSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116D4942AFC382E00314FE3 /* MochiSlider.swift */; };
@@ -126,6 +129,9 @@
 		03FD231A295F7A81006EEEE2 /* Upscaler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Upscaler.swift; sourceTree = "<group>"; };
 		58FF218729FAE96200A70C7C /* ControlNetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlNetView.swift; sourceTree = "<group>"; };
 		71D315152B2A584E007FFDEB /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		9401BC6E2CB9E9E100F00DDE /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		9401BC702CB9ECA500F00DDE /* FilterTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTagView.swift; sourceTree = "<group>"; };
+		9485F21B2CB97B53002623B7 /* FilterTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTextFieldView.swift; sourceTree = "<group>"; };
 		948853A42A543CB200B4AD86 /* GalleryPreviewView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GalleryPreviewView.swift; sourceTree = "<group>"; };
 		9B7392C2298DEAC2006F03D5 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
 		C116D4942AFC382E00314FE3 /* MochiSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MochiSlider.swift; sourceTree = "<group>"; };
@@ -255,6 +261,8 @@
 				0352E2AD294EA2B4003FBF25 /* MessageBanner.swift */,
 				03B1ACA7295167B900302F54 /* SettingsView.swift */,
 				03EA52CD297B66C800CDF661 /* SidebarView.swift */,
+				9485F21B2CB97B53002623B7 /* FilterTextFieldView.swift */,
+				9401BC702CB9ECA500F00DDE /* FilterTagView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -269,6 +277,7 @@
 				03E89F3B294FE6ED0067457E /* SDImage.swift */,
 				03173C122999E2B500B03456 /* SDModel.swift */,
 				D7B03F1F29D42F9900DF89DD /* SDModelAttentionType.swift */,
+				9401BC6E2CB9E9E100F00DDE /* Filter.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -318,7 +327,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1540;
 				TargetAttributes = {
 					036BFC1D294B9F7500D8AD04 = {
 						CreatedOnToolsVersion = 14.2;
@@ -438,8 +447,10 @@
 				C116D4952AFC382E00314FE3 /* MochiSlider.swift in Sources */,
 				0386DF8B2950D29400CA4CEB /* InspectorView.swift in Sources */,
 				948853A52A543CB200B4AD86 /* GalleryPreviewView.swift in Sources */,
+				9401BC6F2CB9E9E100F00DDE /* Filter.swift in Sources */,
 				030370312A2BECDD003D2F0C /* SDControlNet.swift in Sources */,
 				0373FF5429A9165600C0180F /* AppCommands.swift in Sources */,
+				9485F21C2CB97B53002623B7 /* FilterTextFieldView.swift in Sources */,
 				03D280F2294FD60E00C7D184 /* PromptView.swift in Sources */,
 				03FD2319295F74B6006EEEE2 /* RealESRGAN.mlmodel in Sources */,
 				035EE000295A224900080D18 /* ModelView.swift in Sources */,
@@ -452,6 +463,7 @@
 				0352E2B5294EA887003FBF25 /* Functions.swift in Sources */,
 				03173C132999E2B500B03456 /* SDModel.swift in Sources */,
 				0352E2B1294EA30D003FBF25 /* Extensions.swift in Sources */,
+				9401BC712CB9ECA500F00DDE /* FilterTagView.swift in Sources */,
 				03CB9D18297399AE0041A4FA /* ImageCommands.swift in Sources */,
 				71D315162B2A584E007FFDEB /* NotificationController.swift in Sources */,
 				035E76F62970E809008DDFDE /* CVPixelBuffer+Create.swift in Sources */,

--- a/Mochi Diffusion/Model/Filter.swift
+++ b/Mochi Diffusion/Model/Filter.swift
@@ -1,0 +1,74 @@
+//
+//  Filter.swift
+//  Mochi Diffusion
+//
+//  Created by Hossein on 10/12/24.
+//
+
+import Foundation
+
+struct Filter: Identifiable, Equatable {
+    let id = UUID()
+    var text: String
+    var element: FilterElement = .prompt
+    var type: FilterType = .contains
+    var condition: FilterCondition = .isEqual
+}
+
+enum FilterElement: String, CaseIterable {
+    case prompt = "Prompt"
+    case seed = "Seed"
+    case negativePrompt = "Negative Prompt"
+    case model = "Model"
+    case steps = "Steps"
+    case guidanceScale = "Guidance Scale"
+}
+
+enum FilterType: String, CaseIterable {
+    case equals = "Equals"
+    case contains = "Contains"
+}
+
+enum FilterCondition: String, CaseIterable {
+    case isEqual = "= is"
+    case isNotEqual = "≠ is not"
+}
+
+extension Filter {
+    func validate(_ sdImage: SDImage) -> Bool {
+        let filterValue = element.getFilterValueFrom(sdImage)
+        let isContainsType = type == .contains
+
+        let result =
+            isContainsType
+            ? filterValue.range(
+                of: text, options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive])
+                != nil
+            : filterValue == text
+
+        return condition == .isEqual ? result : !result
+    }
+
+    func humanReadable() -> String {
+        return "\(element.rawValue)\(condition == .isEqual ? "" : " not ") \(type.rawValue) \(text)"
+    }
+}
+
+extension Array where Element == Filter {
+    func humanReadable() -> String {
+        self.map({ $0.humanReadable() }).joined(separator: " and ")
+    }
+}
+
+extension FilterElement {
+    func getFilterValueFrom(_ sdImage: SDImage) -> String {
+        switch self {
+        case .prompt: sdImage.prompt
+        case .seed: String(sdImage.seed)
+        case .negativePrompt: sdImage.negativePrompt
+        case .model: sdImage.model
+        case .steps: String(sdImage.steps)
+        case .guidanceScale: String(sdImage.guidanceScale)
+        }
+    }
+}

--- a/Mochi Diffusion/Model/ImageStore.swift
+++ b/Mochi Diffusion/Model/ImageStore.swift
@@ -32,7 +32,7 @@ enum ImagesSortType: String {
 
     private(set) var selectedId: SDImage.ID?
 
-    var searchText: String = "" {
+    var filters: [Filter] = [Filter]() {
         didSet {
             updateFilteredImages()
             updateSortForImages()
@@ -171,10 +171,10 @@ enum ImagesSortType: String {
     }
 
     private func updateFilteredImages() {
-        if searchText.isEmpty {
+        if filters.isEmpty {
             images = allImages
         } else {
-            images = allImages.filter(searchText)
+            images = allImages.filter(filters)
         }
     }
 
@@ -189,11 +189,9 @@ enum ImagesSortType: String {
 }
 
 extension Array where Element == SDImage {
-    fileprivate func filter(_ text: String) -> [SDImage] {
-        self.filter {
-            $0.prompt.range(
-                of: text, options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive])
-                != nil || $0.seed == UInt32(text)
+    fileprivate func filter(_ filters: [Filter]) -> [SDImage] {
+        self.filter { image in
+            filters.allSatisfy({ $0.validate(image) })
         }
     }
 }

--- a/Mochi Diffusion/Views/AppView.swift
+++ b/Mochi Diffusion/Views/AppView.swift
@@ -27,7 +27,6 @@ struct AppView: View {
         .toolbar {
             GalleryToolbarView(isShowingInspector: $isShowingInspector)
         }
-        .searchable(text: $store.searchText, prompt: "Search")
     }
 }
 

--- a/Mochi Diffusion/Views/FilterTagView.swift
+++ b/Mochi Diffusion/Views/FilterTagView.swift
@@ -1,0 +1,118 @@
+//
+//  FilterTagView.swift
+//  Mochi Diffusion
+//
+//  Created by Hossein on 10/12/24.
+//
+
+import SwiftUI
+
+struct FilterTagView: View {
+    @Binding var filter: Filter
+    var isSelected: Bool
+    @State private var isEditing: Bool = false
+    @State private var isOptionsPopoverShown: Bool = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if isEditing {
+                editView
+            } else {
+                tagView
+            }
+        }
+        .cornerRadius(4)
+        .frame(height: 16)
+        .popover(
+            isPresented: $isOptionsPopoverShown,
+            content: {
+                popOverView
+            })
+    }
+
+    private var tagView: some View {
+        HStack(spacing: 1) {
+            Button {
+                isOptionsPopoverShown.toggle()
+            } label: {
+                HStack(spacing: 2) {
+                    if filter.element != .prompt {
+                        Text(filter.element.rawValue)
+                            .fixedSize()
+                    }
+                    Image(systemName: "chevron.down")
+                }
+                .font(.caption2)
+                .padding(.horizontal, 4)
+                .frame(maxHeight: .infinity)
+                .background(isSelected ? Color.gray : Color.gray.opacity(0.5))
+            }
+            .buttonStyle(.plain)
+
+            Text("\(filter.condition == .isEqual ? "" : "≠ ")\"\(filter.text)\"")
+                .padding(.horizontal, 4)
+                .frame(maxHeight: .infinity)
+                .background(isSelected ? Color.gray : Color.gray.opacity(0.3))
+        }
+        .onTapGesture(
+            count: 2,
+            perform: {
+                isEditing = true
+            })
+    }
+
+    private var editView: some View {
+        TextField(
+            "", text: $filter.text,
+            onCommit: {
+                isEditing = false
+            }
+        )
+        .focused($isFocused)
+        .textFieldStyle(PlainTextFieldStyle())
+        .fixedSize()
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private var popOverView: some View {
+        List {
+            ForEach(FilterElement.allCases, id: \.self) { element in
+                FilterOptionItem(element.rawValue, isSelected: filter.element == element)
+                    .onTapGesture {
+                        filter.element = element
+                    }
+            }
+
+            Divider()
+
+            ForEach(FilterType.allCases, id: \.self) { type in
+                FilterOptionItem(type.rawValue, isSelected: filter.type == type)
+                    .onTapGesture {
+                        filter.type = type
+                    }
+            }
+
+            Divider()
+
+            ForEach(FilterCondition.allCases, id: \.self) { condition in
+                FilterOptionItem(condition.rawValue, isSelected: filter.condition == condition)
+                    .onTapGesture {
+                        filter.condition = condition
+                    }
+            }
+        }
+    }
+
+    private func FilterOptionItem(_ text: String, isSelected: Bool) -> some View {
+        HStack {
+            Image(systemName: isSelected ? "checkmark" : "")
+                .frame(width: 12)
+
+            Text(text)
+        }
+        .listRowSeparator(.hidden)
+    }
+}

--- a/Mochi Diffusion/Views/FilterTagView.swift
+++ b/Mochi Diffusion/Views/FilterTagView.swift
@@ -80,7 +80,7 @@ struct FilterTagView: View {
     private var popOverView: some View {
         List {
             ForEach(FilterElement.allCases, id: \.self) { element in
-                FilterOptionItem(element.rawValue, isSelected: filter.element == element)
+                filterOptionItem(element.rawValue, isSelected: filter.element == element)
                     .onTapGesture {
                         filter.element = element
                     }
@@ -89,7 +89,7 @@ struct FilterTagView: View {
             Divider()
 
             ForEach(FilterType.allCases, id: \.self) { type in
-                FilterOptionItem(type.rawValue, isSelected: filter.type == type)
+                filterOptionItem(type.rawValue, isSelected: filter.type == type)
                     .onTapGesture {
                         filter.type = type
                     }
@@ -98,7 +98,7 @@ struct FilterTagView: View {
             Divider()
 
             ForEach(FilterCondition.allCases, id: \.self) { condition in
-                FilterOptionItem(condition.rawValue, isSelected: filter.condition == condition)
+                filterOptionItem(condition.rawValue, isSelected: filter.condition == condition)
                     .onTapGesture {
                         filter.condition = condition
                     }
@@ -106,7 +106,7 @@ struct FilterTagView: View {
         }
     }
 
-    private func FilterOptionItem(_ text: String, isSelected: Bool) -> some View {
+    private func filterOptionItem(_ text: String, isSelected: Bool) -> some View {
         HStack {
             Image(systemName: isSelected ? "checkmark" : "")
                 .frame(width: 12)

--- a/Mochi Diffusion/Views/FilterTextFieldView.swift
+++ b/Mochi Diffusion/Views/FilterTextFieldView.swift
@@ -1,0 +1,83 @@
+//
+//  FilterTextFieldView.swift
+//  Mochi Diffusion
+//
+//  Created by Hossein on 10/11/24.
+//
+
+import SwiftUI
+
+struct FilterTextFieldView: View {
+    @Binding var filters: [Filter]
+    @State private var inputText: String = ""
+    @State private var selectedFilter: Filter? = nil
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+
+            Image(
+                systemName: filters.isEmpty
+                    ? "line.horizontal.3.decrease.circle" : "line.horizontal.3.decrease.circle.fill"
+            )
+            .foregroundColor(filters.isEmpty ? .gray : .accentColor)
+
+            ForEach($filters) { $filter in
+                FilterTagView(filter: $filter, isSelected: selectedFilter == filter)
+                    .onTapGesture {
+                        selectedFilter = filter
+                    }
+            }
+
+            TextField(filters.isEmpty ? "Filter" : "", text: $inputText)
+                .textFieldStyle(.plain)
+                .focused($isFocused)
+                .onSubmit {
+                    addFilter()
+                }
+                .onKeyPress(KeyEquivalent("\u{7F}")) {
+                    guard inputText.isEmpty else { return .ignored }
+                    guard let selectedFilter else {
+                        selectedFilter = filters.last
+                        return .handled
+                    }
+                    removeFilter(selectedFilter)
+                    self.selectedFilter = nil
+                    return .handled
+                }
+
+            if !filters.isEmpty {
+                Button {
+                    filters.removeAll()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                }
+                .buttonStyle(.plain)
+            }
+
+        }
+        .padding(4)
+        .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.gray.opacity(0.5), lineWidth: 1))
+    }
+
+    private func addFilter() {
+        let trimmedText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedText.isEmpty {
+            let newTag = Filter(text: trimmedText)
+            filters.append(newTag)
+            inputText = ""
+        }
+    }
+
+    private func removeFilter(_ filter: Filter) {
+        if let index = filters.firstIndex(of: filter) {
+            filters.remove(at: index)
+        }
+    }
+}
+
+#Preview {
+    @State var filters = [Filter]()
+    return FilterTextFieldView(filters: $filters)
+}

--- a/Mochi Diffusion/Views/GalleryToolbarView.swift
+++ b/Mochi Diffusion/Views/GalleryToolbarView.swift
@@ -118,6 +118,11 @@ struct GalleryToolbarView: View {
                 Image(systemName: "sidebar.right")
             }
         }
+
+        FilterTextFieldView(filters: $store.filters)
+            .frame(minWidth: 300)
+            .frame(maxWidth: 500)
+            .frame(height: 40)
     }
 
     @ViewBuilder

--- a/Mochi Diffusion/Views/GalleryView.swift
+++ b/Mochi Diffusion/Views/GalleryView.swift
@@ -34,10 +34,10 @@ struct GalleryView: View {
                 .resizable(resizingMode: .tile)
         )
         .navigationTitle(
-            store.searchText.isEmpty
+            store.filters.isEmpty
                 ? "Mochi Diffusion"
                 : String(
-                    localized: "Searching: \(store.searchText)",
+                    localized: "Filtering: \(store.filters.humanReadable())",
                     comment: "Window title bar label displaying the searched text"
                 )
         )


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/MochiDiffusion/MochiDiffusion/blob/main/CONTRIBUTING.md)

### Description:
Hello, this PR adds an advanced filter text field to the project, inspired by Xcode logs filtering. The new filter enhances the gallery search functionality by allowing users to refine results based on multiple criteria, such as prompt model, seed, steps count and more. It supports filter options, including "is equal" and "is not equal" conditions, as well as specifying whether the search should match exactly (equal) or simply contain the given text. These additions improve the flexibility and precision of searches within the gallery.

![Screenshot 2024-10-12 at 3 53 10 AM](https://github.com/user-attachments/assets/c0c679c7-e3ad-4e99-87bf-e6eb0ffbf792)
