### PR TITLE
feat: add 'Image > Set as Starting Image' menu item

### DIFF
--- a/Mochi Diffusion/Main Menu/ImageCommands.swift
+++ b/Mochi Diffusion/Main Menu/ImageCommands.swift
@@ -59,6 +59,18 @@ struct ImageCommands: Commands {
             }
             Section {
                 Button {
+                    guard let sdi = store.selected() else { return }
+                    Task { await ImageController.shared.selectStartingImage(sdi: sdi) }
+                } label: {
+                    Text(
+                        "Set as Starting Image",
+                        comment: "Set the current image as the starting image for img2img"
+                    )
+                }
+                .keyboardShortcut("2", modifiers: .command)
+                .disabled(store.selected() == nil)
+
+                Button {
                     Task { await ImageController.shared.upscaleCurrentImage() }
                 } label: {
                     Text(

--- a/Mochi Diffusion/Main Menu/ImageCommands.swift
+++ b/Mochi Diffusion/Main Menu/ImageCommands.swift
@@ -67,7 +67,7 @@ struct ImageCommands: Commands {
                         comment: "Set the current image as the starting image for img2img"
                     )
                 }
-                .keyboardShortcut("2", modifiers: .command)
+                .keyboardShortcut("E", modifiers: .command)
                 .disabled(store.selected() == nil)
 
                 Button {


### PR DESCRIPTION
Add 'Set as Starting Image' command with keyboard shortcut, which allows user to click to select an image, then type Cmd+2 to set as starting image without needing to use mouse/context menu. Useful with Cmd+G to add to generation queue using this new starting image.